### PR TITLE
fix: enhance telemetry fix for Mastra Cloud deployment

### DIFF
--- a/fix-telemetry.js
+++ b/fix-telemetry.js
@@ -8,17 +8,29 @@ const __dirname = path.dirname(__filename);
 
 // Fix telemetry-config.mjs file
 const telemetryConfigPath = path.join(__dirname, '.mastra/output/telemetry-config.mjs');
+const instrumentationPath = path.join(__dirname, '.mastra/output/instrumentation.mjs');
 
 if (fs.existsSync(telemetryConfigPath)) {
-  const content = fs.readFileSync(telemetryConfigPath, 'utf8');
-  
-  // Remove the problematic mastra reference and default export
   const fixedContent = `const telemetry = {
   enabled: false
 };
 
 export { telemetry };`;
-  
+
   fs.writeFileSync(telemetryConfigPath, fixedContent);
   console.log('Fixed telemetry-config.mjs');
+}
+
+// Also fix instrumentation.mjs to inline the telemetry config
+if (fs.existsSync(instrumentationPath)) {
+  let content = fs.readFileSync(instrumentationPath, 'utf8');
+
+  // Replace the import and usage with inline config
+  content = content.replace(
+    /import \{ telemetry \} from ['"]\.\/telemetry-config\.mjs['"];/,
+    'const telemetry = { enabled: false };'
+  );
+
+  fs.writeFileSync(instrumentationPath, content);
+  console.log('Fixed instrumentation.mjs');
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "mastra dev",
     "dev:playground": "node start-playground.js",
     "build": "mastra build && node fix-telemetry.js",
-    "start": "node fix-telemetry.js && node --import=./.mastra/output/instrumentation.mjs .mastra/output/index.mjs",
+    "start": "node start-with-fix.js",
     "start:prod": "./start.sh"
   },
   "keywords": [],

--- a/start-with-fix.js
+++ b/start-with-fix.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { spawn } from 'child_process';
+import fs from 'fs';
+
+// Fix telemetry file
+const fixTelemetry = () => {
+  const telemetryPath = '.mastra/output/telemetry-config.mjs';
+  if (fs.existsSync(telemetryPath)) {
+    const fixedContent = `const telemetry = {
+  enabled: false
+};
+
+export { telemetry };`;
+    fs.writeFileSync(telemetryPath, fixedContent);
+    console.log('Fixed telemetry-config.mjs');
+  }
+};
+
+// Fix immediately before starting
+fixTelemetry();
+
+// Start the server
+const serverProcess = spawn('node', ['--import=./.mastra/output/instrumentation.mjs', '.mastra/output/index.mjs'], {
+  stdio: 'inherit'
+});
+
+serverProcess.on('exit', (code) => {
+  process.exit(code);
+});


### PR DESCRIPTION
- Update fix-telemetry.js to patch instrumentation.mjs
- Inline telemetry config to avoid broken import
- Add start-with-fix.js for runtime telemetry fix
- Update start script to use new wrapper

This fixes the 'mastra is not defined' error in telemetry-config.mjs by replacing the import with an inline constant definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)